### PR TITLE
Fix for 0 results in iteration 13

### DIFF
--- a/starter_code/queries.md
+++ b/starter_code/queries.md
@@ -54,7 +54,7 @@
 
 <!-- Your Code Goes Here -->
 
-### 13. All the companies that have been acquired after 2015, order by the acquisition amount, and retrieve only their `name` and `acquisition` field.
+### 13. All the companies that have been acquired after 2010, order by the acquisition amount, and retrieve only their `name` and `acquisition` field.
 
 <!-- Your Code Goes Here -->
 


### PR DESCRIPTION
In iteration 13, querying for companies acquired after 2015 returns no results. I changed the year to 2010.

@sandrabosk @nizaroni